### PR TITLE
Allow to preset username of user

### DIFF
--- a/auth_user_mgr/_config.py
+++ b/auth_user_mgr/_config.py
@@ -44,6 +44,7 @@ USER_CONFIG_SCHEMA = {
         "properties": {
             "name": {"type": "string"},
             "email": {"type": "string", "format": "email"},
+            "username": {"type": "string"},
             "groups": {
                 "type": "array",
                 "items": {"type": "string"},

--- a/auth_user_mgr/_user.py
+++ b/auth_user_mgr/_user.py
@@ -4,7 +4,7 @@
 
 """Classes and functions for users and groups."""
 
-from slugify import slugify
+from slugify import PRE_TRANSLATIONS, slugify
 
 
 class User:
@@ -44,7 +44,8 @@ class User:
 
         This method uses the `slugify` function to convert the user's name into a username. It uses
         dots as separators for spaces and special characters. It preserves hyphens in the name,
-        allowing for names like "John-William Doe-Testerson" to be converted correctly.
+        allowing for names like "John-William Doe-Testerson" to be converted correctly. Umlauts are
+        replaced with their two-letter equivalents (e.g. ä→ae, ö→oe, ü→ue).
 
         Returns:
             str: The username created by converting the user's name, with a maximum length of 150
@@ -52,15 +53,22 @@ class User:
 
         Examples:
             - "Jane Doe" becomes "jane.doe"
-            - "Mårten Östlund" becomes "marten.ostlund"
+            - "Mårten Östlund" becomes "marten.oestlund"
             - "John-William Doe-Testerson" becomes "john-william.doe-testerson"
+            - "Ärgölü Baß" becomes "aergoelue.bass"
         """
         # Pre-process: replace hyphens (as name combiners) with 'HYPHENHERE' to avoid conflicts with
         # slugify
         name_with_hyphens = self.name.replace("-", "HYPHENHERE")
         # Use slugify to create a username, replacing spaces and special chars with dots. Keep case
-        # to enable replacement of 'HYPHENHERE' later.
-        name_sluggified = slugify(name_with_hyphens, separator=".", max_length=150, lowercase=False)
+        # to enable replacement of 'HYPHENHERE' later. Umlaut replacements are applied first.
+        name_sluggified = slugify(
+            name_with_hyphens,
+            separator=".",
+            max_length=150,
+            lowercase=False,
+            replacements=PRE_TRANSLATIONS,
+        )
         # Post-process: replace 'HYPHENHERE' back to hyphens, and convert to lowercase
         return name_sluggified.replace("HYPHENHERE", "-").lower()
 

--- a/auth_user_mgr/_user.py
+++ b/auth_user_mgr/_user.py
@@ -20,20 +20,23 @@ class User:
         invite_slug (str): The invitation slug generated from the user's name.
     """
 
-    def __init__(self, name: str, email: str, configured_groups: list[str]) -> None:
+    def __init__(
+        self, name: str, email: str, configured_groups: list[str], username: str = ""
+    ) -> None:
         """
         Args:
             name (str): The name of the user.
             email (str): The email address of the user.
             configured_groups (list[str]): The list of groups the user is configured to be
                 a member of.
+            username (str, optional): A preset username. If empty, auto-generated from the name.
         """
         self.id: int
         self.name: str = name
         self.email: str = email
         self.current_groups: list[str]
         self.configured_groups: list[str] = sorted(configured_groups)
-        self.username = self.user_name_to_username()
+        self.username = username or self.user_name_to_username()
         self.invite_slug = self.user_name_to_invite_slug()
 
     def user_name_to_username(self) -> str:

--- a/auth_user_mgr/main.py
+++ b/auth_user_mgr/main.py
@@ -140,6 +140,11 @@ class UserSync:
         self.users_deleted: int = 0
         self.detail_messages: list[str] = []
 
+    @staticmethod
+    def _user_label(email: str, username: str) -> str:
+        """Format a user identifier as 'email (username)' for display."""
+        return f"{email} ({username})"
+
     def sync_user(self, user: User, invitation_template: str = "") -> None:
         """Synchronize a single user: check existence, handle invitations, sync groups.
 
@@ -187,7 +192,8 @@ class UserSync:
                     invite_uuid,
                 )
                 self.detail_messages.append(
-                    f"{user.email}: deleting stale invitation {invite_uuid}"
+                    f"{self._user_label(user.email, user.username)}: "
+                    f"deleting stale invitation {invite_uuid}"
                 )
                 # Delete invitation
                 self.api.delete_invitation(invitation_uuid=invite_uuid)
@@ -196,7 +202,10 @@ class UserSync:
 
         # Check if user is pending invitation. If not, create invitation
         if invite_url := self.api.get_pending_invitation_url_for_email(user.email):
-            self.detail_messages.append(f"{user.email}: pending invitation: {invite_url}")
+            self.detail_messages.append(
+                f"{self._user_label(user.email, user.username)}: "
+                f"pending invitation: {invite_url}"
+            )
         else:
             invitation_url = self.api.create_invitation(user=user)
             logging.info(
@@ -210,7 +219,8 @@ class UserSync:
                 invitation_expiry_days=self.api.invitation_expiry_days,
             )
             self.detail_messages.append(
-                f"{user.email}: invitation created and sent: {invitation_url}"
+                f"{self._user_label(user.email, user.username)}: "
+                f"invitation created and sent: {invitation_url}"
             )
 
         return False
@@ -255,7 +265,9 @@ class UserSync:
             self.api.delete_user_from_group(
                 user_id=user.id, group_uuid=self.group_name_uuid_cache[group]
             )
-            self.detail_messages.append(f"{user.email}: removed from group '{group}'")
+            self.detail_messages.append(
+                f"{self._user_label(user.email, user.username)}: removed from group '{group}'"
+            )
 
         # Add user to groups
         for group in add_to_groups:
@@ -265,7 +277,9 @@ class UserSync:
             self.api.add_user_to_group(
                 user_id=user.id, group_uuid=self.group_name_uuid_cache[group]
             )
-            self.detail_messages.append(f"{user.email}: added to group '{group}'")
+            self.detail_messages.append(
+                f"{self._user_label(user.email, user.username)}: added to group '{group}'"
+            )
 
         return has_changes
 
@@ -306,9 +320,12 @@ class UserSync:
                 logging.info("Skipping deletion of user %s (type: %s)", email, user_type)
                 continue
             user_id = user_dict.get("pk", 0)
+            username = user_dict.get("username", "")
             logging.info("Deleting unconfigured user %s (ID: %s)", email, user_id)
             self.api.delete_user(user_id=user_id)
-            self.detail_messages.append(f"{email}: deleted (not in user inventory)")
+            self.detail_messages.append(
+                f"{self._user_label(email, username)}: deleted (not in user inventory)"
+            )
             self.users_deleted += 1
 
 

--- a/auth_user_mgr/main.py
+++ b/auth_user_mgr/main.py
@@ -379,6 +379,7 @@ def cli() -> None:
                 name=user_dict.get("name", ""),
                 email=user_dict.get("email", ""),
                 configured_groups=user_dict.get("groups", []),
+                username=user_dict.get("username", ""),
             )
             configured_emails.add(user.email)
             sync.sync_user(user=user)

--- a/config/users.sample.yaml
+++ b/config/users.sample.yaml
@@ -8,6 +8,7 @@
 
 - name: Jane Doe
   email: jane@example.com
+  # username: jane.doe2  # Optional: override auto-generated username
 
 - name: John Doe
   email: john@example.net

--- a/tests/data/sample/users.sample.yaml
+++ b/tests/data/sample/users.sample.yaml
@@ -10,6 +10,7 @@
 
 - name: Jane Doe
   email: jane@example.com
+  # username: jane.doe2  # Optional: override auto-generated username
 
 - name: John Doe
   email: john@example.net

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,6 +36,7 @@ def test_check_existence_user_exists_stale_invitation(sample_sync: UserSync) -> 
     assert result is True
     sample_sync.api.delete_invitation.assert_called_once_with(invitation_uuid="inv-abc")
     assert len(sample_sync.detail_messages) == 1
+    assert "tester@example.com (tester.testerson)" in sample_sync.detail_messages[0]
     assert "deleting stale invitation" in sample_sync.detail_messages[0]
 
 
@@ -50,6 +51,7 @@ def test_check_existence_user_not_found_pending_invitation(sample_sync: UserSync
 
     assert result is False
     assert len(sample_sync.detail_messages) == 1
+    assert "new@example.com (new.user)" in sample_sync.detail_messages[0]
     assert "pending invitation" in sample_sync.detail_messages[0]
 
 
@@ -65,6 +67,7 @@ def test_check_existence_user_not_found_creates_invitation(sample_sync: UserSync
     sample_sync.api.create_invitation.assert_called_once_with(user=user)
     sample_sync.mail.send_email.assert_called_once()
     assert len(sample_sync.detail_messages) == 1
+    assert "new@example.com (new.user)" in sample_sync.detail_messages[0]
     assert "invitation created and sent" in sample_sync.detail_messages[0]
 
 
@@ -98,6 +101,7 @@ def test_check_group_memberships_add_group(sample_sync: UserSync) -> None:
     assert result is True
     sample_sync.api.add_user_to_group.assert_called_once_with(user_id=1, group_uuid="uuid-group-3")
     assert len(sample_sync.detail_messages) == 1
+    assert "tester@example.com (tester.testerson)" in sample_sync.detail_messages[0]
     assert "added to group 'Group 3'" in sample_sync.detail_messages[0]
 
 
@@ -114,6 +118,7 @@ def test_check_group_memberships_remove_group(sample_sync: UserSync) -> None:
         user_id=1, group_uuid="uuid-group-2"
     )
     assert len(sample_sync.detail_messages) == 1
+    assert "tester@example.com (tester.testerson)" in sample_sync.detail_messages[0]
     assert "removed from group 'Group 2'" in sample_sync.detail_messages[0]
 
 
@@ -258,7 +263,12 @@ def test_handle_unconfigured_users_deletes_internal(sample_sync: UserSync) -> No
     sample_sync.delete_unconfigured_users = True
     sample_sync.all_users_by_email = {
         "configured@example.com": {"pk": 1, "email": "configured@example.com", "type": "internal"},
-        "extra@example.com": {"pk": 2, "email": "extra@example.com", "type": "internal"},
+        "extra@example.com": {
+            "pk": 2,
+            "email": "extra@example.com",
+            "type": "internal",
+            "username": "extra.user",
+        },
     }
     sample_sync.api.delete_user = MagicMock()
 
@@ -267,7 +277,8 @@ def test_handle_unconfigured_users_deletes_internal(sample_sync: UserSync) -> No
     sample_sync.api.delete_user.assert_called_once_with(user_id=2)
     assert sample_sync.users_deleted == 1
     assert len(sample_sync.detail_messages) == 1
-    assert "extra@example.com: deleted" in sample_sync.detail_messages[0]
+    assert "extra@example.com (extra.user)" in sample_sync.detail_messages[0]
+    assert "deleted" in sample_sync.detail_messages[0]
 
 
 def test_handle_unconfigured_users_skips_service_accounts(sample_sync: UserSync) -> None:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -47,3 +47,21 @@ def test_user_with_very_long_name() -> None:
     assert len(user.invite_slug) <= 50
     assert len(user.username) <= 150
     assert user.invite_slug.startswith("invite-firstname")
+
+
+def test_user_with_preset_username() -> None:
+    """Test user with a preset username overrides auto-generation."""
+    user = User(
+        name="Jane Doe",
+        email="jane@example.com",
+        configured_groups=[],
+        username="custom.jane",
+    )
+    assert user.username == "custom.jane"
+    assert user.name == "Jane Doe"
+
+
+def test_user_with_empty_username_falls_back() -> None:
+    """Test user with empty username falls back to auto-generation from name."""
+    user = User(name="Jane Doe", email="jane@example.com", configured_groups=[], username="")
+    assert user.username == "jane.doe"

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -22,7 +22,7 @@ def test_user_initialization_and_properties() -> None:
 def test_user_with_special_characters() -> None:
     """Test user with special characters in the name."""
     user = User(name="Mårten Östlund", email="marten@example.com", configured_groups=["X"])
-    assert user.username == "marten.ostlund"
+    assert user.username == "marten.oestlund"
     assert user.invite_slug.startswith("invite-marten-ostlund")
 
 
@@ -65,3 +65,12 @@ def test_user_with_empty_username_falls_back() -> None:
     """Test user with empty username falls back to auto-generation from name."""
     user = User(name="Jane Doe", email="jane@example.com", configured_groups=[], username="")
     assert user.username == "jane.doe"
+
+
+def test_user_with_umlauts() -> None:
+    """Test that German umlauts are transliterated to two-letter equivalents."""
+    user = User(name="Jürgen Müller", email="jm@example.com", configured_groups=[])
+    assert user.username == "juergen.mueller"
+
+    user2 = User(name="Ärgölü Baß", email="test@example.com", configured_groups=[])
+    assert user2.username == "aergoelue.bass"


### PR DESCRIPTION
Right now, the username is compiled from a user's full name. This is unwanted in edge cases:
* Two users with the same name
* Very long name, therefore long username
* Special characters in name

This option now allows to preset the username.