### PR TITLE
feat: write GitHub Step Summary by default

### DIFF
--- a/auth_user_mgr/main.py
+++ b/auth_user_mgr/main.py
@@ -11,6 +11,7 @@ group membership synchronization, and provides a command-line interface for oper
 
 import argparse
 import logging
+import os
 from pathlib import Path
 
 from . import __version__
@@ -313,21 +314,66 @@ class UserSync:
 
         return has_changes
 
-    def print_summary(self, total_users: int) -> None:
+    def print_summary(self, total_users: int, dry_run: bool = False) -> None:
         """Print sync summary and detail messages.
 
         Args:
             total_users (int): Total number of configured users processed.
+            dry_run (bool): Whether this sync was executed in dry-run mode.
         """
         print(f"Sync summary: {total_users} users processed")
         print(f"  Unchanged: {self.users_unchanged}")
         print(f"  Changed:   {self.users_changed}")
         print(f"  Pending:   {self.users_pending}")
         print(f"  Deleted:   {self.users_deleted}")
+        if dry_run:
+            print("\n⚠️ Dry run: no productive changes and no emails sent")
         if self.detail_messages:
             print("\nDetails:")
             for msg in self.detail_messages:
                 print(f"  {msg}")
+
+        self.write_github_step_summary(total_users=total_users, dry_run=dry_run)
+
+    def write_github_step_summary(self, total_users: int, dry_run: bool = False) -> None:
+        """Append sync summary to GitHub Actions step summary when available.
+
+        Args:
+            total_users (int): Total number of configured users processed.
+            dry_run (bool): Whether this sync was executed in dry-run mode.
+        """
+        summary_path = os.getenv("GITHUB_STEP_SUMMARY", "").strip()
+        if not summary_path:
+            return
+
+        summary_lines = [
+            "### Sync summary",
+            "",
+            f"- Users processed: {total_users}",
+            f"- Unchanged: {self.users_unchanged}",
+            f"- Changed: {self.users_changed}",
+            f"- Pending: {self.users_pending}",
+            f"- Deleted: {self.users_deleted}",
+        ]
+        if dry_run:
+            summary_lines.extend(["", "⚠️ Dry run: no productive changes and no emails sent"])
+
+        if self.detail_messages:
+            summary_lines.extend(
+                [
+                    "",
+                    f"<details><summary>Details ({len(self.detail_messages)})</summary>",
+                    "",
+                ]
+            )
+            summary_lines.extend([f"- {msg}" for msg in self.detail_messages])
+            summary_lines.extend(["", "</details>"])
+
+        try:
+            with Path(summary_path).open(mode="a", encoding="utf-8") as summary_file:
+                summary_file.write("\n".join(summary_lines) + "\n")
+        except OSError as err:
+            logging.warning("Could not write GitHub step summary to %s: %s", summary_path, err)
 
     def handle_unconfigured_users(self, configured_emails: set[str]) -> None:
         """Delete users from Authentik that are not in the configured user inventory.
@@ -431,7 +477,7 @@ def run_sync(config: str, users: str, dry: bool, no_email: bool) -> None:
     # Delete unconfigured users if enabled
     sync.handle_unconfigured_users(configured_emails=configured_emails)
 
-    sync.print_summary(total_users=len(cfg_users))
+    sync.print_summary(total_users=len(cfg_users), dry_run=dry)
 
 
 def run_import(input_file: str, groups_args: str, output: str, users: str, dry: bool) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@
 
 """Tests for main.py."""
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -226,6 +227,105 @@ def test_print_summary_with_details(sample_sync: UserSync, capsys: pytest.Captur
     assert "Details:" in captured.out
     assert "bob@example.com: added to group 'Admin'" in captured.out
     assert "new@example.com: invitation created and sent" in captured.out
+
+
+def test_print_summary_writes_github_step_summary_with_collapsed_details(
+    sample_sync: UserSync,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test print_summary writes GitHub step summary with collapsed details block."""
+    summary_file = tmp_path / "step-summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+
+    sample_sync.users_unchanged = 3
+    sample_sync.users_changed = 1
+    sample_sync.users_pending = 1
+    sample_sync.users_deleted = 0
+    sample_sync.detail_messages = [
+        "bob@example.com: added to group 'Admin'",
+        "new@example.com: invitation created and sent: https://example.com/inv",
+    ]
+
+    sample_sync.print_summary(total_users=5)
+
+    content = summary_file.read_text(encoding="utf-8")
+    assert "### Sync summary" in content
+    assert "- Users processed: 5" in content
+    assert "- Unchanged: 3" in content
+    assert "- Changed: 1" in content
+    assert "- Pending: 1" in content
+    assert "- Deleted: 0" in content
+    assert "<details><summary>Details (2)</summary>" in content
+    assert "- bob@example.com: added to group 'Admin'" in content
+    assert "- new@example.com: invitation created and sent: https://example.com/inv" in content
+    assert "</details>" in content
+
+
+def test_print_summary_writes_github_step_summary_without_details(
+    sample_sync: UserSync,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test print_summary writes GitHub step summary without details block."""
+    summary_file = tmp_path / "step-summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+
+    sample_sync.users_unchanged = 5
+    sample_sync.users_changed = 0
+    sample_sync.users_pending = 0
+    sample_sync.users_deleted = 0
+    sample_sync.detail_messages = []
+
+    sample_sync.print_summary(total_users=5)
+
+    content = summary_file.read_text(encoding="utf-8")
+    assert "### Sync summary" in content
+    assert "- Users processed: 5" in content
+    assert "<details>" not in content
+
+
+def test_print_summary_dry_run_notice_in_stdout(
+    sample_sync: UserSync, capsys: pytest.CaptureFixture
+) -> None:
+    """Test print_summary emits dry-run notice between summary and details."""
+    sample_sync.users_unchanged = 1
+    sample_sync.users_changed = 0
+    sample_sync.users_pending = 0
+    sample_sync.users_deleted = 0
+    sample_sync.detail_messages = ["x@example.com: pending invitation: https://example.com/i"]
+
+    sample_sync.print_summary(total_users=1, dry_run=True)
+
+    captured = capsys.readouterr()
+    expected_notice = "⚠️ Dry run: no productive changes and no emails sent"
+    assert expected_notice in captured.out
+    assert captured.out.find("Deleted:") < captured.out.find(expected_notice)
+    assert captured.out.find(expected_notice) < captured.out.find("Details:")
+
+
+def test_print_summary_writes_github_step_summary_with_dry_run_notice(
+    sample_sync: UserSync,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test GitHub step summary includes dry-run notice before details."""
+    summary_file = tmp_path / "step-summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+
+    sample_sync.users_unchanged = 1
+    sample_sync.users_changed = 0
+    sample_sync.users_pending = 0
+    sample_sync.users_deleted = 0
+    sample_sync.detail_messages = ["x@example.com: pending invitation: https://example.com/i"]
+
+    sample_sync.print_summary(total_users=1, dry_run=True)
+
+    content = summary_file.read_text(encoding="utf-8")
+    expected_notice = "⚠️ Dry run: no productive changes and no emails sent"
+    assert expected_notice in content
+    assert content.find("- Deleted: 0") < content.find(expected_notice)
+    assert content.find(expected_notice) < content.find("<details><summary>Details (1)</summary>")
 
 
 def test_get_groups_of_users(sample_api: AuthentikAPI, mock_api_call: callable) -> None:


### PR DESCRIPTION
Based on env variables the tool figures out if it's running in a GitHub workflow, and writes its output in a slightly different format to the GitHub Step Summary.

Also adds an indicator when running in dry mode.